### PR TITLE
Number references in order of appearance

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,10 @@ function factory(definitions) {
      * @param {Node} parent - Parent of `node`.
      */
     function item(node, index, parent) {
+        if (node.type !== 'image' && node.type !== 'link') {
+            return;
+        }
+
         var link = node.src || node.href;
         var replacement;
         var identifier;
@@ -86,8 +90,7 @@ function transformer(node) {
     var children = node.children;
     var link;
 
-    visit(node, 'image', collect);
-    visit(node, 'link', collect);
+    visit(node, collect);
 
     for (link in definitions) {
         children.push(definitions[link]);

--- a/test.js
+++ b/test.js
@@ -47,3 +47,24 @@ test('remark-reference-links', function (t) {
         t.end();
     });
 });
+
+test('reference links are numbered in order they\'re seen', function (t) {
+    remark.use(referenceLinks).process([
+        '[foo](http://example.com/1 "Example Domain 1") ' +
+          '![foo](http://example.com/2 "Example Domain 2")',
+        ''
+    ].join('\n'), function (err, file, doc) {
+        t.ifErr(err);
+
+        t.equal(doc, [
+            '[foo][1] ![foo][2]',
+            '',
+            '[1]: http://example.com/1 "Example Domain 1"',
+            '',
+            '[2]: http://example.com/2 "Example Domain 2"',
+            ''
+        ].join('\n'));
+
+        t.end();
+    });
+});


### PR DESCRIPTION
Previously, images were always processed first and hence claimed the first few reference IDs, leading to confusing results in large documents.

This change moves the check for node type into the visitor callback rather than having unist-util-visit do the check, so links and images have the same precedence, in terms of what reference link numbers they claim.

Test included.
